### PR TITLE
Link to bzip2 library on iOS platform

### DIFF
--- a/config/Make.rules
+++ b/config/Make.rules
@@ -292,7 +292,7 @@ LDFLAGS	= $(LDPLATFORMFLAGS) $(COMPFLAGS) $(if $(ice_language:cpp=),-ObjC,)
 ifeq ($(PLATFORM_NAME),macosx)
 ICE_OS_LIBS 	= -framework Security -framework Foundation -lbz2 -liconv
 else
-ICE_OS_LIBS 	= -framework UIKit -framework CFNetwork -framework Security -framework Foundation -liconv
+ICE_OS_LIBS 	= -framework UIKit -framework CFNetwork -framework Security -framework Foundation -lbz2 -liconv
 endif
 
 MCPP_LIBS 	= $(if $(MCPP_HOME),-L$(MCPP_HOME)/$(libsubdir)) -lmcpp


### PR DESCRIPTION
Without supporting bzip2 compression on iOS targets I always end up with

```
ConnectionI.cpp:3366: Ice::FeatureNotSupportedException:
feature `Cannot uncompress compressed message' is not supported.
```

exceptions.
